### PR TITLE
perf(msem_tile_trimmer): load resin_mask for all MFOVs of a slab in batches of scans

### DIFF
--- a/src/python/janelia_emrp/msem/ingestion_ibeammsem/metrics.py
+++ b/src/python/janelia_emrp/msem/ingestion_ibeammsem/metrics.py
@@ -54,9 +54,9 @@ def get_timestamp(xlog: xr.Dataset, scan: int, slab: int, mfov: int) -> datetime
 
 def get_resin_mask(
     xlog: xr.Dataset,
-    scan: int,
+    scan: slice | list[int],
     slab: int,
-    mfov: int,
+    mfov: slice | list[int] = slice(0, None),
     n_pixels_low: int = 50**2,
     n_pixels_high: int = 50**2,
     threshold_width: int = 35,
@@ -86,7 +86,7 @@ def get_resin_mask(
     sel = dict(scan=scan, slab=slab, mfov=mfov)
     cumulative_histogram = xlog[XVar.HISTOGRAM].sel(sel).cumulative(XDim.BIN).sum()
 
-    n_pixels = cumulative_histogram.isel(sfov=0, bin=-1).values.item()
+    n_pixels = cumulative_histogram.isel(scan=0, mfov=0, sfov=0, bin=-1).values.item()
     threshold_low = n_pixels_low
     threshold_high = n_pixels - n_pixels_high
 

--- a/src/python/janelia_emrp/msem/msem_tile_trimmer.py
+++ b/src/python/janelia_emrp/msem/msem_tile_trimmer.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 import sys
-from itertools import groupby
+from itertools import groupby, batched
 import traceback
 from pathlib import Path
 from typing import List, Any
@@ -88,9 +88,10 @@ def create_trimmed_stacks(render_ws_host_and_port: str,
 
         # process 10 z layers at a time to reduce the total number of requests
         # while ensuring we don't exceed the maximum number of tiles per request (currently 100,000)
-        for i in range(0, len(z_values), 10):
-            min_z = z_values[i]
-            max_z = z_values[min(i + 9, len(z_values) - 1)]
+        for z_batch in batched(z_values, 10):
+            min_z = min(z_batch)
+            max_z = max(z_batch)
+
 
             resolved_tiles = render_request.get_all_resolved_tiles_for_stack(stack=stack,
                                                                              min_z=min_z,


### PR DESCRIPTION
@trautmane
- **refactor(msem_tile_trimmer): use itertools.batched**
- **feat(metrics): load resin mask for ranges of SCAN/MFOV**
- **perf(msem_tile_trimmer): load resin_mask for all MFOVs in batches of scans**
